### PR TITLE
Start initial work on a Python 3 port

### DIFF
--- a/inbox/client/client.py
+++ b/inbox/client/client.py
@@ -185,7 +185,7 @@ class APIClient(json.JSONEncoder):
 
         response = self._get_http_session(cls.api_root).get(url)
         results = _validate(response).json()
-        return map(lambda x: cls.create(self, namespace, **x), results)
+        return list(map(lambda x: cls.create(self, namespace, **x), results))
 
     @inbox_excepted
     def _get_resource_raw(self, namespace, cls, id, **filters):
@@ -242,7 +242,7 @@ class APIClient(json.JSONEncoder):
             response = session.post(url, data=data, headers=headers)
 
         results = _validate(response).json()
-        return map(lambda x: cls.create(self, namespace, **x), results)
+        return list(map(lambda x: cls.create(self, namespace, **x), results))
 
     @inbox_excepted
     def _delete_resource(self, namespace, cls, id):

--- a/inbox/client/errors.py
+++ b/inbox/client/errors.py
@@ -4,7 +4,7 @@ import json
 class APIClientError(Exception):
     def __init__(self, **kwargs):
         self.attrs = kwargs.keys()
-        for k, v in kwargs.iteritems():
+        for k, v in kwargs.items():
             setattr(self, k, v)
 
         Exception.__init__(self, str(kwargs))

--- a/inbox/client/restful_models.py
+++ b/inbox/client/restful_models.py
@@ -1,5 +1,5 @@
 from .restful_model_collection import RestfulModelCollection
-from cStringIO import StringIO
+from six import StringIO
 import base64
 import json
 
@@ -18,9 +18,13 @@ class InboxAPIObject(dict):
         self.api = api
         self.namespace = namespace
 
-    __getattr__ = dict.__getitem__
     __setattr__ = dict.__setitem__
     __delattr__ = dict.__delitem__
+
+    def __getattr__(self, what):
+        if what not in self:
+            raise AttributeError("no such attribute: '{}'".format(what))
+        return self[what]
 
     @classmethod
     def create(cls, api, namespace_, **kwargs):


### PR DESCRIPTION
This just gets the tests passing, no further work in validating the bindings on Python 3 was done yet.

Interesting notes - since `__getitem__` raises a `KeyError`, not an `AttributeError`, `hasattr` would bomb out. Neat.

This also eagerly consumes the `map` (since it's -- rightly -- an iterator), and does something similar with `.items` (which will be an iterator in Python 3 - I opted to not do two codepaths there, since the gain looks to be minimal usually)